### PR TITLE
Complete Code-along

### DIFF
--- a/lib/garden.rb
+++ b/lib/garden.rb
@@ -1,4 +1,4 @@
-# Something is missing here
+require_relative './plant'
 
 class Garden
   attr_accessor :name


### PR DESCRIPTION
This pull request adds a missing dependency to the `Garden` class by requiring the `plant` file.

* [`lib/garden.rb`](diffhunk://#diff-65a7c5fc0473708b25e119bbb698c7e7a1bd212a5445e1a6a5d37a3cf4271d11L1-R1): Added `require_relative './plant'` to ensure the `Garden` class has access to the `Plant` class or module.